### PR TITLE
fix: repair back-office attribute routing broken by sf7.4 migration

### DIFF
--- a/Controller/ChronopostPickupPointBackOfficeController.php
+++ b/Controller/ChronopostPickupPointBackOfficeController.php
@@ -20,15 +20,15 @@ use Thelia\Model\LangQuery;
 
 /**
  */
+#[Route('/admin/module/ChronopostPickupPoint', name: 'ChronopostPickupPoint')]
 class ChronopostPickupPointBackOfficeController extends BaseAdminController
 {
     /**
      * Render the module config page
      *
-     * @Route("/config", name="_config", methods="POST")
      * @return Response
      */
-    /*public function viewAction($tab)
+    public function viewAction(string $tab = 'configure')
     {
         return $this->render(
             'module-configure',
@@ -37,12 +37,11 @@ class ChronopostPickupPointBackOfficeController extends BaseAdminController
                 'current_tab' => $tab,
             ]
         );
-    }*/
+    }
 
     /**
-     * @Route("/saveLabel", name="_saveLabel", methods="POST")
      */
-    #[Route('/admin/module/ChronopostPickupPoint', name: 'ChronopostPickupPoint')]
+    #[Route('/saveLabel', name: '_saveLabel')]
     public function saveLabel(RequestStack $requestStack)
     {
         if (null !== $response = $this->checkAuth([AdminResources::MODULE], 'ChronopostPickupPoint', AccessManager::UPDATE)) {

--- a/Controller/ChronopostPickupPointFreeShippingController.php
+++ b/Controller/ChronopostPickupPointFreeShippingController.php
@@ -18,15 +18,15 @@ use Symfony\Component\Routing\Attribute\Route;
 
 /**
  */
+#[Route('/admin/module/chronopost-pickup-point', name: 'chronopost-pickup-point')]
 class ChronopostPickupPointFreeShippingController extends BaseAdminController
 {
     /**
      * Toggle free shipping for the delivery type being edited.
      *
-     * @Route("/freeshipping", name="_freeshipping", methods="POST")
      * @return mixed|null|Response|static
      */
-    #[Route('/admin/module/chronopost-pickup-point', name: 'chronopost-pickup-point')]
+    #[Route('/freeshipping', name: '_freeshipping', methods: ['POST'])]
     public function toggleFreeShippingActivation()
     {
         if (null !== $response = $this->checkAuth(array(AdminResources::MODULE), array('ChronopostPickupPoint'), AccessManager::UPDATE)) {

--- a/Controller/ChronopostPickupPointFrontController.php
+++ b/Controller/ChronopostPickupPointFrontController.php
@@ -13,14 +13,14 @@ use Symfony\Component\Routing\Attribute\Route;
 
 /**
  */
+#[Route('/chronopost/pickup-point', name: 'chronopost-pickup-point_front')]
 class ChronopostPickupPointFrontController extends BaseFrontController
 {
     /**
-     * @Route("/save", name="_save_address", methods="GET")
      * @return Response
      * @throws \Propel\Runtime\Exception\PropelException
      */
-    #[Route('/chronopost/pickup-point', name: 'chronopost-pickup-point_front')]
+    #[Route('/save', name: '_save_address', methods: ['GET'])]
     public function saveAddressAction(RequestStack $requestStack)
     {
         $request = $requestStack->getCurrentRequest();

--- a/Controller/ChronopostPickupPointRelayController.php
+++ b/Controller/ChronopostPickupPointRelayController.php
@@ -10,12 +10,12 @@ use Symfony\Component\Routing\Attribute\Route;
 
 /**
  */
+#[Route('/admin/module/chronopost-pickup-point', name: 'chronopost-pickup-point')]
 class ChronopostPickupPointRelayController extends BaseAdminController
 {
     /**
-     * @Route("/coordinates", name="_coordinates", methods="POST")
      */
-    #[Route('/admin/module/chronopost-pickup-point', name: 'chronopost-pickup-point')]
+    #[Route('/coordinates', name: '_coordinates', methods: ['POST'])]
     public function findByAddress($orderWeight, $address, $zipCode, $city, $countryCode)
     {
         $config = ChronopostPickupPointConst::getConfig();

--- a/Controller/ChronopostPickupPointSliceController.php
+++ b/Controller/ChronopostPickupPointSliceController.php
@@ -26,16 +26,15 @@ use Thelia\Core\Security\AccessManager;
 
 /**
  */
+#[Route('/admin/module/chronopost-pickup-point/slice', name: 'chronopost-pickup-point_slice')]
 class ChronopostPickupPointSliceController extends BaseAdminController
 {
     /**
      * Save/Create a price slice in the delivery type being edited.
      *
      * @return mixed|Response|null
-     *
-     * @Route("/save", name="_save", methods="POST")
      */
-    #[Route('/admin/module/chronopost-pickup-point/slice', name: 'chronopost-pickup-point_slice')]
+    #[Route('/save', name: '_save', methods: ['POST'])]
     public function saveSliceAction()
     {
         $response = $this->checkAuth([], ['chronopost'], AccessManager::UPDATE);


### PR DESCRIPTION
Same regression as ChronopostHomeDelivery: the migration to attribute routing dropped the class-level URL prefix and left method routes with bare relative paths, so the config-save / delivery-mode / freeshipping / slice / coordinates / front endpoints no longer matched the URLs emitted by the templates (they 404'd or fell through to the wrong action).

- Move the URL prefix to a class-level #[Route] on every controller (matching the existing TaxRuleController convention), keeping method paths relative. Final URLs now match the (commented) Config/routing.xml.
- Restore viewAction() as a helper with a default $tab so saveAction() and saveLabel() error paths no longer call an undefined method.